### PR TITLE
[codex] Fix planner feat application bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.2.2
+
+### Level Planner
+
+- **Ancestral Paragon granted ancestry feats now keep their planned subchoices visible** - Granted ancestry-feat slots under `Ancestral Paragon` now surface their own choice sets in the planner UI, so picks that should appear nested under the granted feat no longer vanish from the select menu or fall back to odd bonus-feat placement behavior
+- **Arcane Evolution skill-training choices now apply during level-up** - Planned feat-driven skill training is now applied alongside normal skill increases, so choices like `Stealth` from `Arcane Evolution` correctly make the actor trained when the plan is applied
+- **Draconic Advanced Bloodline now applies Dragon Breath** - Sorcerer advanced bloodline focus-spell application now overrides bad draconic focus UUID data by resolving `Dragon Breath` directly, so draconic and wyrmblessed sorcerers get the correct advanced focus spell at apply time
+
 ## 3.2.1
 
 ### Suggested Character Options

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-leveler",
   "title": "PF2e Leveler",
   "description": "<p>Create, Plan and auto-apply character level-ups for Pathfinder 2E. Plan your entire build from level 1 to 20, with prerequisite validation and automatic application on level change.</p>",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "compatibility": {
     "minimum": "13",
     "verified": "14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pf2e-leveler",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Plan and auto-apply character level-ups for Pathfinder 2E",
   "main": "scripts/main.js",
   "scripts": {

--- a/scripts/apply/apply-skills.js
+++ b/scripts/apply/apply-skills.js
@@ -4,10 +4,11 @@ export async function applySkillIncreases(actor, plan, level) {
   const levelData = plan.levels[level];
   const skillIncreases = [...(levelData?.skillIncreases ?? []), ...(levelData?.customSkillIncreases ?? [])];
   const intBonusSkills = levelData?.intBonusSkills ?? [];
+  const featSkillRules = getLevelFeatSkillRules(levelData);
   const featLoreRules = ['classFeats', 'skillFeats', 'generalFeats', 'ancestryFeats', 'archetypeFeats', 'mythicFeats', 'dualClassFeats', 'customFeats']
     .flatMap((key) => levelData?.[key] ?? [])
     .flatMap((feat) => feat?.dynamicLoreRules ?? []);
-  if (skillIncreases.length === 0 && intBonusSkills.length === 0 && featLoreRules.length === 0) return [];
+  if (skillIncreases.length === 0 && intBonusSkills.length === 0 && featSkillRules.length === 0 && featLoreRules.length === 0) return [];
 
   const updates = {};
   const applied = [];
@@ -36,6 +37,27 @@ export async function applySkillIncreases(actor, plan, level) {
       updates[`system.skills.${skill}.rank`] = 1;
     }
     applied.push({ skill, toRank: 1, intBonus: true });
+  }
+
+  for (const rule of featSkillRules) {
+    const skill = String(rule?.skill ?? '').trim().toLowerCase();
+    if (!skill) continue;
+
+    const currentRank = getPendingSkillRank(actor, updates, skill);
+    const rawTargetRank = currentRank >= 1 && rule?.valueIfAlreadyTrained != null
+      ? rule.valueIfAlreadyTrained
+      : rule?.value;
+    const toRank = Number(rawTargetRank ?? 1);
+    if (!Number.isFinite(toRank) || toRank <= currentRank) continue;
+
+    if (skill.endsWith('-lore') || !SKILLS.includes(skill)) {
+      loreItemsToCreate.push({ skill, toRank });
+      applied.push({ skill, toRank, featChoice: true });
+      continue;
+    }
+
+    updates[`system.skills.${skill}.rank`] = toRank;
+    applied.push({ skill, toRank, featChoice: true });
   }
 
   for (const rule of featLoreRules) {
@@ -82,6 +104,21 @@ export async function applySkillIncreases(actor, plan, level) {
   }
 
   return applied;
+}
+
+function getLevelFeatSkillRules(levelData) {
+  return ['classFeats', 'skillFeats', 'generalFeats', 'ancestryFeats', 'archetypeFeats', 'mythicFeats', 'dualClassFeats', 'customFeats']
+    .flatMap((key) => levelData?.[key] ?? [])
+    .flatMap((feat) => [
+      ...(Array.isArray(feat?.skillRules) ? feat.skillRules : []),
+      ...(Array.isArray(feat?.dynamicSkillRules) ? feat.dynamicSkillRules : []),
+    ]);
+}
+
+function getPendingSkillRank(actor, updates, skill) {
+  const pendingRank = updates[`system.skills.${skill}.rank`];
+  if (Number.isFinite(pendingRank)) return pendingRank;
+  return Number(actor.system?.skills?.[skill]?.rank ?? 0);
 }
 
 function slugify(value) {

--- a/scripts/apply/apply-spells.js
+++ b/scripts/apply/apply-spells.js
@@ -14,6 +14,14 @@ const ADVANCED_FOCUS_FEAT_SLUGS = ['advanced-bloodline', 'advanced-mystery', 'ad
 const GREATER_FOCUS_FEAT_SLUGS = ['greater-bloodline', 'greater-mystery', 'greater-order', 'greater-revelation'];
 const FEAT_KEYS = ['classFeats', 'skillFeats', 'generalFeats', 'ancestryFeats', 'archetypeFeats', 'mythicFeats', 'dualClassFeats', 'customFeats'];
 const MAGUS_STUDIOUS_ENTRY_FLAG = 'magusStudiousEntry';
+const SUBCLASS_FOCUS_SPELL_NAME_OVERRIDES = {
+  'bloodline-draconic': {
+    advanced: 'Dragon Breath',
+  },
+  'bloodline-wyrmblessed': {
+    advanced: 'Dragon Breath',
+  },
+};
 
 export async function applySpells(actor, plan, level) {
   const addedSpells = [];
@@ -513,9 +521,14 @@ async function addSubclassFocusSpells(actor, classDef, plan, level) {
 
   const subclassData = SUBCLASS_SPELLS[subclassItem.slug];
   const focusSpellUuid = subclassData?.focusSpells?.[focusTier];
-  if (!focusSpellUuid) return [];
+  const focusSpellNameOverride = SUBCLASS_FOCUS_SPELL_NAME_OVERRIDES[subclassItem.slug]?.[focusTier] ?? null;
+  if (!focusSpellUuid && !focusSpellNameOverride) return [];
 
-  const spell = await resolveSpell(focusSpellUuid);
+  let spell = focusSpellUuid ? await resolveSpell(focusSpellUuid) : null;
+  if (focusSpellNameOverride && spell?.name !== focusSpellNameOverride) {
+    const overrideSpell = await resolveSpellByName(focusSpellNameOverride);
+    if (overrideSpell) spell = overrideSpell;
+  }
   if (!spell) return [];
 
   const existing = actor.items?.find((i) =>
@@ -632,4 +645,21 @@ async function resolveSpell(uuid) {
     warn(`Failed to resolve spell: ${uuid}`);
     return null;
   }
+}
+
+async function resolveSpellByName(name) {
+  const pack = game?.packs?.get?.('pf2e.spells-srd')
+    ?? [...(game?.packs ?? [])].find((entry) => entry?.collection === 'pf2e.spells-srd');
+  if (!pack) return null;
+
+  const index = typeof pack.getIndex === 'function'
+    ? await pack.getIndex({ fields: ['name'] })
+    : (pack.index ?? []);
+  const match = [...index].find((entry) => String(entry?.name ?? '').trim().toLowerCase() === String(name).trim().toLowerCase());
+  if (!match) return null;
+
+  const uuid = typeof match.uuid === 'string' && match.uuid.length > 0
+    ? match.uuid
+    : (typeof match._id === 'string' && match._id.length > 0 ? `Compendium.pf2e.spells-srd.Item.${match._id}` : null);
+  return uuid ? resolveSpell(uuid) : null;
 }

--- a/scripts/ui/level-planner/level-context.js
+++ b/scripts/ui/level-planner/level-context.js
@@ -40,6 +40,9 @@ export async function buildLevelContext(planner, classDef, options) {
   const classFeatChoiceSets = await buildPlannerFeatChoiceSets(planner, classFeat);
   const generalFeatChoiceSets = await buildPlannerFeatChoiceSets(planner, generalFeat);
   const ancestryFeatChoiceSets = await buildPlannerFeatChoiceSets(planner, ancestryFeat);
+  const generalFeatGrantedAncestryFeat = generalFeatGrantsAncestryFeat
+    ? mergePlannerChoiceSetsIntoFeat(ancestryFeat, ancestryFeatChoiceSets)
+    : ancestryFeat;
   const archetypeFeat = await enrichPlannerFeat(planner, extractFeat(levelData.archetypeFeats));
   const archetypeFeatChoiceSets = await buildPlannerFeatChoiceSets(planner, archetypeFeat);
   const customFeats = await buildCustomPlannerFeatEntries(planner, levelData.customFeats ?? []);
@@ -74,7 +77,7 @@ export async function buildLevelContext(planner, classDef, options) {
     ancestryFeat,
     ancestryFeatChoiceSets,
     showGeneralFeatGrantedAncestryFeat: generalFeatGrantsAncestryFeat,
-    generalFeatGrantedAncestryFeat: ancestryFeat,
+    generalFeatGrantedAncestryFeat,
     showSkillIncrease: choiceTypes.has('skillIncrease') && !planner._shouldHideHistoricalSkillIncrease(level),
     availableSkills: planner._buildSkillContext(levelData, level),
     showArchetypeFeat: choiceTypes.has('archetypeFeat'),
@@ -609,6 +612,14 @@ function dedupePlannerChoiceSets(choiceSets) {
   }
 
   return deduped;
+}
+
+function mergePlannerChoiceSetsIntoFeat(feat, choiceSets) {
+  if (!feat) return feat;
+  return {
+    ...feat,
+    grantChoiceSets: dedupePlannerChoiceSets([...(feat.grantChoiceSets ?? []), ...(choiceSets ?? [])]),
+  };
 }
 
 function getChoiceSetSignature(entry) {

--- a/tests/unit/apply/apply-skills.test.js
+++ b/tests/unit/apply/apply-skills.test.js
@@ -67,4 +67,33 @@ describe('applySkillIncreases', () => {
       { skill: 'acrobatics', toRank: 3 },
     ]);
   });
+
+  test('applies skill training granted by planned feat choice rules', async () => {
+    mockActor.system = {
+      skills: {
+        stealth: { rank: 0 },
+      },
+    };
+
+    const plan = {
+      levels: {
+        4: {
+          classFeats: [{
+            slug: 'arcane-evolution',
+            skillRules: [],
+            dynamicSkillRules: [{ skill: 'stealth', value: 1, source: 'choice:levelerskillchoice1' }],
+          }],
+        },
+      },
+    };
+
+    const result = await applySkillIncreases(mockActor, plan, 4);
+
+    expect(mockActor.update).toHaveBeenCalledWith({
+      'system.skills.stealth.rank': 1,
+    });
+    expect(result).toEqual([
+      { skill: 'stealth', toRank: 1, featChoice: true },
+    ]);
+  });
 });

--- a/tests/unit/apply/apply-spells.test.js
+++ b/tests/unit/apply/apply-spells.test.js
@@ -84,7 +84,8 @@ describe('applySpells', () => {
     jest.restoreAllMocks();
   });
 
-  test('adds advanced subclass focus spell when advanced bloodline is applied', async () => {
+  test('adds dragon breath for draconic advanced bloodline even if stored focus UUID resolves to the wrong spell', async () => {
+    const originalGame = global.game;
     const plan = {
       classSlug: 'sorcerer',
       levels: {
@@ -96,29 +97,91 @@ describe('applySpells', () => {
       },
     };
 
-    const added = await applySpells(actor, plan, 8);
+    actor.items = [
+      actor.items[0],
+      {
+        type: 'feat',
+        slug: 'bloodline-draconic',
+        system: { traits: { otherTags: ['sorcerer-bloodline'] } },
+        flags: { pf2e: { rulesSelections: { dragonBloodline: 'red' } } },
+      },
+    ];
 
-    expect(actor.createEmbeddedDocuments).toHaveBeenCalledWith('Item', [
-      expect.objectContaining({
-        name: 'Sorcerer Focus Spells',
-        type: 'spellcastingEntry',
-      }),
-    ]);
-    expect(actor.createEmbeddedDocuments).toHaveBeenCalledWith('Item', [
-      expect.objectContaining({
-        name: 'Wish-Twisted Form',
-        system: expect.objectContaining({
-          location: { value: 'created-entry-0' },
-        }),
-      }),
-    ]);
-    expect(actor.update).toHaveBeenCalledWith({
-      'system.resources.focus.max': 2,
-      'system.resources.focus.value': 2,
+    global.game = {
+      ...(originalGame ?? {}),
+      packs: new Map([
+        ['pf2e.spells-srd', {
+          getIndex: jest.fn(async () => [{
+            uuid: 'Compendium.pf2e.spells-srd.Item.dragon-breath',
+            name: 'Dragon Breath',
+          }]),
+        }],
+      ]),
+    };
+
+    global.fromUuid = jest.fn(async (uuid) => {
+      if (uuid === 'Compendium.pf2e.spells-srd.Item.HWJODX2zPg5cg34F') {
+        return {
+          uuid,
+          name: 'Wrong Focus Spell',
+          img: 'wrong.png',
+          system: {
+            traits: { value: ['focus'], traditions: [] },
+          },
+          toObject: () => ({
+            name: 'Wrong Focus Spell',
+            system: {
+              traits: { value: ['focus'], traditions: [] },
+            },
+          }),
+        };
+      }
+      if (uuid === 'Compendium.pf2e.spells-srd.Item.dragon-breath') {
+        return {
+          uuid,
+          name: 'Dragon Breath',
+          img: 'dragon-breath.png',
+          system: {
+            traits: { value: ['focus'], traditions: [] },
+          },
+          toObject: () => ({
+            name: 'Dragon Breath',
+            system: {
+              traits: { value: ['focus'], traditions: [] },
+            },
+          }),
+        };
+      }
+      return null;
     });
-    expect(added).toEqual(expect.arrayContaining([
-      expect.objectContaining({ name: 'Wish-Twisted Form' }),
-    ]));
+
+    try {
+      const added = await applySpells(actor, plan, 8);
+
+      expect(actor.createEmbeddedDocuments).toHaveBeenCalledWith('Item', [
+        expect.objectContaining({
+          name: 'Sorcerer Focus Spells',
+          type: 'spellcastingEntry',
+        }),
+      ]);
+      expect(actor.createEmbeddedDocuments).toHaveBeenCalledWith('Item', [
+        expect.objectContaining({
+          name: 'Dragon Breath',
+          system: expect.objectContaining({
+            location: { value: 'created-entry-0' },
+          }),
+        }),
+      ]);
+      expect(actor.update).toHaveBeenCalledWith({
+        'system.resources.focus.max': 2,
+        'system.resources.focus.value': 2,
+      });
+      expect(added).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'Dragon Breath' }),
+      ]));
+    } finally {
+      global.game = originalGame;
+    }
   });
 
   test('creates and updates separate secondary dual-class spellcasting entries', async () => {

--- a/tests/unit/ui/level-planner-bootstrap.test.js
+++ b/tests/unit/ui/level-planner-bootstrap.test.js
@@ -1099,6 +1099,70 @@ describe('LevelPlanner bootstrap from existing actor', () => {
     expect(context.showAncestryFeat).toBe(false);
   });
 
+  it('surfaces direct choice sets on the ancestry feat granted by Ancestral Paragon', async () => {
+    const originalFromUuid = global.fromUuid;
+
+    const actor = createMockActor({ items: [] });
+    actor.class.slug = 'alchemist';
+
+    const planner = new LevelPlanner(actor);
+    planner.plan = createPlan('alchemist');
+    planner.selectedLevel = 3;
+    planner.plan.levels[3].generalFeats = [{
+      uuid: 'Compendium.pf2e.feats-srd.Item.ancestral-paragon',
+      slug: 'ancestral-paragon',
+      name: 'Ancestral Paragon',
+      level: 3,
+    }];
+    planner.plan.levels[3].ancestryFeats = [{
+      uuid: 'Compendium.test.Item.clever-adaptation',
+      slug: 'clever-adaptation',
+      name: 'Clever Adaptation',
+      level: 1,
+      choices: { skill: 'stealth' },
+    }];
+
+    global.fromUuid = jest.fn(async (uuid) => {
+      if (uuid === 'Compendium.test.Item.clever-adaptation') {
+        return {
+          uuid,
+          slug: 'clever-adaptation',
+          name: 'Clever Adaptation',
+          system: {
+            description: { value: '' },
+            rules: [{
+              key: 'ChoiceSet',
+              flag: 'skill',
+              prompt: 'Select a skill.',
+              choices: [{ value: 'stealth', label: 'Stealth' }],
+              leveler: { grantsSkillTraining: true },
+            }],
+          },
+        };
+      }
+
+      return null;
+    });
+
+    try {
+      const context = await planner._buildLevelContext(ClassRegistry.get('alchemist'), planner._getVariantOptions());
+      expect(context.showGeneralFeatGrantedAncestryFeat).toBe(true);
+      expect(context.showAncestryFeat).toBe(false);
+      expect(context.generalFeatGrantedAncestryFeat.grantChoiceSets).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          flag: 'skill',
+          prompt: 'Select a skill.',
+          grantsSkillTraining: true,
+          options: expect.arrayContaining([
+            expect.objectContaining({ value: 'stealth', selected: true }),
+          ]),
+        }),
+      ]));
+    } finally {
+      global.fromUuid = originalFromUuid;
+    }
+  });
+
   it('shows an ancestry selector under Adopted Ancestry general feats', async () => {
     const actor = createMockActor({ items: [] });
     actor.class.slug = 'alchemist';


### PR DESCRIPTION
## What changed
Fixes three planner/apply bugs in the feat flow:

- surfaces granted ancestry-feat choice sets under `Ancestral Paragon`
- applies feat-granted skill training during level-up, including planned `Arcane Evolution` picks
- resolves the draconic/wyrmblessed advanced bloodline focus spell to `Dragon Breath` when the stored UUID is wrong
- bumps the patch release to `3.2.2` and adds changelog notes

## Why
These bugs came from three separate gaps in the plan-to-apply pipeline:

- granted ancestry feats had their direct choice sets built, but not attached to the granted feat slot shown under `Ancestral Paragon`
- build-state/planner logic understood `dynamicSkillRules`, but runtime skill application only applied normal increases and lore rules
- draconic advanced bloodline relied on bad focus-spell UUID data, so apply used the wrong focus spell

## Impact
Planned feat subchoices now stay visible where users expect them, feat-driven skill training actually lands on the actor during apply, and draconic sorcerers get the correct advanced focus spell.

## Validation
- `npm test -- tests/unit/apply/apply-skills.test.js tests/unit/apply/apply-spells.test.js tests/unit/ui/level-planner-bootstrap.test.js`
- `npx eslint scripts/apply/apply-skills.js scripts/apply/apply-spells.js scripts/ui/level-planner/level-context.js tests/unit/apply/apply-skills.test.js tests/unit/apply/apply-spells.test.js tests/unit/ui/level-planner-bootstrap.test.js`
- full repo hooks on commit:
  - `eslint .`
  - `jest --maxWorkers=50%`