### PR TITLE
fix(prereqs): recognize "can cast <spell> cantrip" prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 3.2.3
 
-### Level Planner
-
-- **Feats that require casting a specific cantrip or spell now recognize the requirement** - Prerequisites phrased as `you can cast the shield cantrip`, `able to cast the X cantrip`, or `you can cast the X spell` are now parsed and checked against the character's known spells, so feats like `Shield Spell Reinforcement` correctly unlock for characters who have the referenced cantrip
-
 ### Item Picker
 
 - **Item picker filters now match the compact feat and spell picker layout** - Search and trait filtering now sit together at the top, the level filter is an inline `Level` row with plain level values, and obvious standalone labels were removed from simple inputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.2.3
 
+### Level Planner
+
+- **Feats that require casting a specific cantrip or spell now recognize the requirement** - Prerequisites phrased as `you can cast the shield cantrip`, `able to cast the X cantrip`, or `you can cast the X spell` are now parsed and checked against the character's known spells, so feats like `Shield Spell Reinforcement` correctly unlock for characters who have the referenced cantrip
+
 ### Item Picker
 
 - **Item picker filters now match the compact feat and spell picker layout** - Search and trait filtering now sit together at the top, the level filter is an inline `Level` row with plain level values, and obvious standalone labels were removed from simple inputs

--- a/scripts/prerequisites/matchers.js
+++ b/scripts/prerequisites/matchers.js
@@ -232,6 +232,13 @@ export function matchSpellcastingState(parsed, buildState) {
     };
   }
 
+  if (parsed.spellSlug) {
+    return {
+      met: !!buildState.spellcasting?.spellNames?.has(parsed.spellSlug),
+      text: parsed.text,
+    };
+  }
+
   if (parsed.spellTrait) {
     return {
       met: !!buildState.spellcasting?.spellTraits?.has(parsed.spellTrait),

--- a/scripts/prerequisites/parsers.js
+++ b/scripts/prerequisites/parsers.js
@@ -62,6 +62,10 @@ const FOCUS_SPELLS_PATTERN = /^ability to cast focus spells$/i;
 const SPECIFIC_SPELL_WITH_SLOT_PATTERN = /^able to cast\s+(.+?)\s+with a spell slot$/i;
 const SPELL_SLOTS_PATTERN = /^(?:ability|able) to cast spells (?:from|using) spell slots$/i;
 const SPELL_TRAIT_PATTERN = /^able to cast at least one\s+(.+?)\s+spell$/i;
+const SPECIFIC_CANTRIP_PATTERN =
+  /^(?:you\s+(?:can|must\s+be\s+able\s+to)\s+cast|able\s+to\s+cast|ability\s+to\s+cast|have)\s+(?:the\s+)?(.+?)\s+cantrip$/i;
+const SPECIFIC_SPELL_PATTERN =
+  /^(?:you\s+(?:can|must\s+be\s+able\s+to)\s+cast|able\s+to\s+cast|ability\s+to\s+cast)\s+the\s+(.+?)\s+spell$/i;
 const SPELLCASTING_TRADITION_PATTERN =
   /^ability to cast\s+(arcane|divine|occult|primal)\s+spells?$/i;
 const SUBCLASS_TRADITION_PATTERN =
@@ -481,6 +485,24 @@ function tryParseSpellcastingRequirement(text, fullText = text) {
       type: 'spellcastingState',
       spellSlots: true,
       spellSlug: slugify(specificSpellWithSlotMatch[1]),
+      text: fullText,
+    };
+  }
+
+  const cantripMatch = text.match(SPECIFIC_CANTRIP_PATTERN);
+  if (cantripMatch) {
+    return {
+      type: 'spellcastingState',
+      spellSlug: slugify(cantripMatch[1]),
+      text: fullText,
+    };
+  }
+
+  const specificSpellMatch = text.match(SPECIFIC_SPELL_PATTERN);
+  if (specificSpellMatch) {
+    return {
+      type: 'spellcastingState',
+      spellSlug: slugify(specificSpellMatch[1]),
       text: fullText,
     };
   }

--- a/tests/unit/prerequisites/matchers.test.js
+++ b/tests/unit/prerequisites/matchers.test.js
@@ -466,6 +466,22 @@ describe('matchSpellcastingState', () => {
     expect(result.met).toBe(true);
   });
 
+  test('meets specific-cantrip prerequisite when actor knows the cantrip', () => {
+    const result = matchSpellcastingState(
+      { type: 'spellcastingState', spellSlug: 'shield', text: 'you can cast the shield cantrip' },
+      { spellcasting: { spellNames: new Set(['shield']) } },
+    );
+    expect(result.met).toBe(true);
+  });
+
+  test('fails specific-cantrip prerequisite when actor does not know the cantrip', () => {
+    const result = matchSpellcastingState(
+      { type: 'spellcastingState', spellSlug: 'shield', text: 'you can cast the shield cantrip' },
+      { spellcasting: { spellNames: new Set(['light']) } },
+    );
+    expect(result.met).toBe(false);
+  });
+
   test('meets spell-trait prerequisite when actor can cast a matching spell trait', () => {
     const result = matchSpellcastingState(
       { type: 'spellcastingState', spellTrait: 'necromancy', text: 'able to cast at least one necromancy spell' },

--- a/tests/unit/prerequisites/parsers.test.js
+++ b/tests/unit/prerequisites/parsers.test.js
@@ -176,6 +176,28 @@ describe('parsePrerequisite', () => {
     expect(result.spellSlug).toBe('animate-dead');
   });
 
+  test('parses specific-cantrip prerequisite wording variants', () => {
+    for (const text of [
+      'you can cast the shield cantrip',
+      'able to cast the shield cantrip',
+      'ability to cast the shield cantrip',
+      'you must be able to cast the shield cantrip',
+      'have the shield cantrip',
+    ]) {
+      const result = parsePrerequisite(text);
+      expect(result.type).toBe('spellcastingState');
+      expect(result.spellSlug).toBe('shield');
+      expect(result.spellSlots).toBeUndefined();
+    }
+  });
+
+  test('parses specific-spell (non-slot) prerequisite wording', () => {
+    const result = parsePrerequisite('you can cast the fireball spell');
+    expect(result.type).toBe('spellcastingState');
+    expect(result.spellSlug).toBe('fireball');
+    expect(result.spellSlots).toBeUndefined();
+  });
+
   test('parses spell-trait casting prerequisite', () => {
     const result = parsePrerequisite('able to cast at least one necromancy spell');
     expect(result.type).toBe('spellcastingState');


### PR DESCRIPTION
Fixes #54

## Summary
- Adds parser patterns for prerequisites phrased as "you can cast the X cantrip", "able to cast the X cantrip", "ability to cast the X cantrip", "have the X cantrip", and "you can cast the X spell".
- Extends `matchSpellcastingState` with a `spellSlug`-only branch that checks `buildState.spellcasting.spellNames` without requiring a spell slot (so cantrips qualify).
- Adds unit tests covering both the parser variants and matcher success/failure cases.

## Root cause
The prereq on *Shield Spell Reinforcement* is literally `you can cast the shield cantrip`. None of the existing spellcasting patterns matched that phrase, so it fell through to `tryParseFeatRequirement`, was slugified to the non-existent feat `you-can-cast-the-shield-cantrip`, and was reported as unmet — even when the character had the Shield cantrip in their spellcasting entries.

`buildState.spellcasting.spellNames` already collects every owned and planned spell item's slug, so the matcher change is just a lookup against that set.

## Test plan
- [x] `parsePrerequisite('you can cast the shield cantrip')` returns `{ type: 'spellcastingState', spellSlug: 'shield' }` (covered by new test)
- [x] `matchSpellcastingState` with `spellSlug: 'shield'` is met when `spellNames` contains `shield`, fails otherwise (covered by new tests)
- [x] Verified live on a Wizard with the Shield cantrip and planned War Mage Dedication: feat is now selectable after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)