### PR TITLE
Fix class feature prerequisites

### DIFF
--- a/scripts/classes/swashbuckler.js
+++ b/scripts/classes/swashbuckler.js
@@ -15,6 +15,7 @@ export const SWASHBUCKLER = {
   abilityBoostSchedule: [5, 10, 15, 20],
 
   classFeatures: [
+    { level: 1, name: 'Precise Strike', key: 'precise-strike' },
     { level: 3, name: 'Fortitude Expertise', key: 'fortitude-expertise' },
     { level: 3, name: 'Opportune Riposte', key: 'opportune-riposte' },
     { level: 3, name: 'Stylish Tricks', key: 'stylish-tricks' },

--- a/scripts/ui/character-wizard/index.js
+++ b/scripts/ui/character-wizard/index.js
@@ -1363,6 +1363,14 @@ export class CharacterWizard extends HandlebarsApplicationMixin(ApplicationV2) {
       ...(this.data.grantedFeatSections ?? []),
     ], classState);
 
+    const classDef = classSlug ? ClassRegistry.get(classSlug) : null;
+    const classFeatures = new Set();
+    for (const feature of classDef?.classFeatures ?? []) {
+      if (feature.level > level) continue;
+      if (feature.key) classFeatures.add(feature.key);
+      if (feature.name) classFeatures.add(slugify(feature.name));
+    }
+
     return {
       level,
       class: classState,
@@ -1374,6 +1382,7 @@ export class CharacterWizard extends HandlebarsApplicationMixin(ApplicationV2) {
       attributes,
       skills: skillsMap,
       divineFont: classSelections.divineFont,
+      classFeatures,
     };
   }
 

--- a/tests/unit/classes/swashbuckler.test.js
+++ b/tests/unit/classes/swashbuckler.test.js
@@ -1,0 +1,38 @@
+import { SWASHBUCKLER } from '../../../scripts/classes/swashbuckler.js';
+import { getChoicesForLevel } from '../../../scripts/classes/progression.js';
+
+describe('Swashbuckler class definition', () => {
+  test('has correct basic properties', () => {
+    expect(SWASHBUCKLER.slug).toBe('swashbuckler');
+    expect(SWASHBUCKLER.keyAbility).toEqual(['dex']);
+    expect(SWASHBUCKLER.hp).toBe(10);
+  });
+
+  test('class feats start at level 2', () => {
+    expect(SWASHBUCKLER.featSchedule.class[0]).toBe(2);
+  });
+
+  test('ability boosts exclude level 1', () => {
+    expect(SWASHBUCKLER.abilityBoostSchedule).toEqual([5, 10, 15, 20]);
+  });
+
+  test('no spellcasting', () => {
+    expect(SWASHBUCKLER.spellcasting).toBeNull();
+  });
+
+  test('level 2 choices include class feat and skill feat', () => {
+    const types = getChoicesForLevel(SWASHBUCKLER, 2).map((c) => c.type);
+    expect(types).toContain('classFeat');
+    expect(types).toContain('skillFeat');
+  });
+
+  test('Precise Strike is a level 1 class feature', () => {
+    const preciseStrike = SWASHBUCKLER.classFeatures.find((f) => f.key === 'precise-strike');
+    expect(preciseStrike).toBeDefined();
+    expect(preciseStrike.level).toBe(1);
+  });
+
+  test('class features include entries starting at level 1', () => {
+    expect(SWASHBUCKLER.classFeatures[0].level).toBe(1);
+  });
+});

--- a/tests/unit/ui/character-wizard-feats.test.js
+++ b/tests/unit/ui/character-wizard-feats.test.js
@@ -22,6 +22,7 @@ import { saveCreationData } from '../../../scripts/creation/creation-store.js';
 import { getClassHandler } from '../../../scripts/creation/class-handlers/registry.js';
 import { MIXED_ANCESTRY_UUID } from '../../../scripts/constants.js';
 import { invalidateGuidanceCache } from '../../../scripts/access/content-guidance.js';
+import { SWASHBUCKLER } from '../../../scripts/classes/swashbuckler.js';
 const { getCreationData } = jest.requireMock('../../../scripts/creation/creation-store.js');
 
 jest.mock('../../../scripts/creation/creation-store.js', () => ({
@@ -2643,5 +2644,26 @@ describe('CharacterWizard feat step ancestry filtering', () => {
       { uuid: 'a', sourcePack: 'module.alpha', sourceLabel: 'Alpha Pack' },
     ]);
     expect(filtered.selectedCantrips).toEqual([{ uuid: 'x', name: 'Keep Me' }]);
+  });
+
+  it('includes class features in the build state used for prerequisite checking', async () => {
+    ClassRegistry.register(SWASHBUCKLER);
+
+    const wizard = new CharacterWizard(createMockActor());
+    wizard.data.class = {
+      slug: 'swashbuckler',
+      name: 'Swashbuckler',
+      uuid: 'Compendium.pf2e.classes.Item.Swashbuckler',
+    };
+    wizard._getClassTrainedSkills = jest.fn(async () => []);
+    wizard._getBackgroundTrainedSkills = jest.fn(async () => []);
+    wizard._buildCreationAbilityModifiers = jest.fn(async () => ({}));
+    wizard._collectHeritageGrantedTraits = jest.fn(async () => []);
+    wizard._collectSenses = jest.fn(async () => []);
+
+    const buildState = await wizard._buildCreationFeatBuildState();
+
+    expect(buildState.classFeatures).toBeInstanceOf(Set);
+    expect(buildState.classFeatures.has('precise-strike')).toBe(true);
   });
 });


### PR DESCRIPTION
While using the character wizard to make a Swashbuckler I discovered I was unable to take the Flying Blade class feat. This was incorrect as it's prerequisite was precise strike, a Swashbuckler class feature gained at level one. This PR addresses that issue:

- The Character Wizard never included classFeatures in the build state used for prerequisite checking, so any feat that requires a class feature as a prerequisite was always blocked during character creation — regardless of class.
- Fixed by computing classFeatures from the class definition in _buildCreationFeatBuildState, filtered to the character's current level.
- Added Precise Strike at level 1 to the Swashbuckler class definition as the first discovered case — it's a genuine level 1 Swashbuckler class feature (confirmed on Archives of Nethys) and is a prerequisite for Flying Blade.

I tested this on a local Foundry instance with leveler installed and patched the fix into it. I was able to pick Flying Blade in the wizard after that.

Note: sorry for the closed PR -- it had a lot of unexpected changes from my setup.