### PR TITLE
Fix prerequisite parsing, Oracle Time revelation spells, and sheet launcher

### DIFF
--- a/lang/cn.json
+++ b/lang/cn.json
@@ -1,5 +1,13 @@
 {
     "PF2E_LEVELER": {
+        "MODULE_TITLE": "PF2e Leveler",
+        "KEYBINDINGS": {
+            "OPEN_LEVELER": {
+                "NAME": "打开 PF2e Leveler",
+                "HINT": "为一个选中的角色指示物或分配给你的角色打开等级规划器。"
+            },
+            "NO_ACTOR": "请先选择一个你拥有的角色指示物，或为你的用户分配一个角色。"
+        },
         "UI": {
             "LEVEL": "{level}级",
             "EXPORT": "导出规划",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,13 @@
 {
   "PF2E_LEVELER": {
     "MODULE_TITLE": "PF2e Leveler",
+    "KEYBINDINGS": {
+      "OPEN_LEVELER": {
+        "NAME": "Open PF2e Leveler",
+        "HINT": "Open the level planner for one selected token or your assigned character."
+      },
+      "NO_ACTOR": "Select one owned character token or assign a character to your user first."
+    },
     "UI": {
       "OPEN_PLANNER": "Plan Levels",
       "LEVEL": "Level {level}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1,6 +1,13 @@
 {
   "PF2E_LEVELER": {
     "MODULE_TITLE": "PF2e Leveler",
+    "KEYBINDINGS": {
+      "OPEN_LEVELER": {
+        "NAME": "Ouvrir PF2e Leveler",
+        "HINT": "Ouvre le planificateur de niveaux pour un jeton sélectionné ou pour le personnage qui vous est attribué."
+      },
+      "NO_ACTOR": "Sélectionnez un jeton de personnage que vous possédez ou attribuez d’abord un personnage à votre utilisateur."
+    },
     "UI": {
       "OPEN_PLANNER": "Planifier les niveaux",
       "LEVEL": "Niveau {level}",

--- a/scripts/data/subclass-spells.js
+++ b/scripts/data/subclass-spells.js
@@ -494,7 +494,11 @@ export const SUBCLASS_SPELLS = {
   },
   // oracle — Time
   'time': {
-    focusSpells: { "initial": "Compendium.pf2e.spells-srd.Item.UbHK19RYbxRXWgWX", "advanced": "Compendium.pf2e.spells-srd.Item.MT8usUfwudDVUm5H" },
+    focusSpells: {
+      initial: 'Compendium.pf2e.spells-srd.Item.UbHK19RYbxRXWgWX',
+      advanced: 'Compendium.pf2e.spells-srd.Item.LbqunTurwXB3u9Vp',
+      greater: 'Compendium.pf2e.spells-srd.Item.MT8usUfwudDVUm5H',
+    },
     grantedSpells: { "1": "Compendium.pf2e.spells-srd.Item.rerNA6YZsdxuJYt3", "3": "Compendium.pf2e.spells-srd.Item.0Rl3W7kiq9xVZRcr", "7": "Compendium.pf2e.spells-srd.Item.G56DJkxlUjFv0C4Z", "cantrip": "Compendium.pf2e.spells-srd.Item.BvNbDwFYaidKJG9j" },
   },
   // magus — Twisting Tree

--- a/scripts/hooks/lifecycle.js
+++ b/scripts/hooks/lifecycle.js
@@ -2,7 +2,7 @@ import { registerSettings, migrateWealthSettings } from '../settings.js';
 import { migrateLegacyFeatCompendiumsSetting } from '../compendiums/catalog.js';
 import { ClassRegistry } from '../classes/registry.js';
 import { ensureClassRegistry } from '../classes/ensure.js';
-import { registerSheetIntegration } from '../ui/sheet-integration.js';
+import { registerLevelerKeybindings, registerSheetIntegration } from '../ui/sheet-integration.js';
 import { ensureLevelerTemplatesLoaded } from '../ui/template-preload.js';
 import { info } from '../utils/logger.js';
 import { registerReviewRequestSocket } from '../access/review-requests.js';
@@ -18,6 +18,7 @@ async function onInit() {
   info('Initializing module');
 
   registerSettings();
+  registerLevelerKeybindings();
   await migrateLegacyFeatCompendiumsSetting();
   registerClasses();
   registerHandlebarsHelpers();

--- a/scripts/prerequisites/matchers.js
+++ b/scripts/prerequisites/matchers.js
@@ -148,6 +148,19 @@ export function matchHeritage(parsed, buildState) {
   };
 }
 
+export function matchAncestry(parsed, buildState) {
+  const required = normalizeText(parsed.slug);
+  const ancestrySlug = normalizeText(buildState.ancestrySlug);
+  const ancestryTraits = buildState.ancestryTraits instanceof Set
+    ? buildState.ancestryTraits
+    : new Set(buildState.ancestryTraits ?? []);
+  const normalizedTraits = new Set([...ancestryTraits].map((trait) => normalizeText(trait)));
+  return {
+    met: ancestrySlug === required || normalizedTraits.has(required),
+    text: parsed.text,
+  };
+}
+
 export function matchAncestryFeatAccess(parsed, buildState) {
   if (parsed.multipleAncestries !== true) {
     return { met: null, text: parsed.text };

--- a/scripts/prerequisites/parsers.js
+++ b/scripts/prerequisites/parsers.js
@@ -20,6 +20,11 @@ const RANK_NAME_ALIASES = {
   legendaire: 'legendary',
   inexperimente: 'untrained',
   inexperimentee: 'untrained',
+  ungeubt: 'untrained',
+  geubt: 'trained',
+  experte: 'expert',
+  meister: 'master',
+  legende: 'legendary',
 };
 
 const RANK_NAME_PATTERN = [
@@ -28,6 +33,11 @@ const RANK_NAME_PATTERN = [
   'ma(?:i|î)tre',
   'l(?:e|é)gendaire',
   'inexp(?:e|é)riment(?:e|é)(?:e)?',
+  'unge(?:u|ü)bt',
+  'ge(?:u|ü)bt',
+  'experte',
+  'meister',
+  'legende',
 ].join('|');
 const RANK_CONNECTOR_PATTERN = '(?:in|en)';
 const OR_WORD_PATTERN = '(?:or|ou)';
@@ -86,7 +96,8 @@ const SUBCLASS_TRADITION_PATTERN =
 const GENERIC_BARD_MUSE_PATTERN = /^(?:bard muse|muse de barde)$/i;
 const CLASS_FEATURE_PATTERN = /^(.+?)\s+class feature$/i;
 const BACKGROUND_PATTERN = /^(.+?)\s+background$/i;
-const HERITAGE_PATTERN = /^(.+?)\s+heritage$/i;
+const ANCESTRY_PATTERN = /^(.+?)\s+(?:ancestry|abstammung)$/iu;
+const HERITAGE_PATTERN = /^(.+?)\s+(?:heritage|herkunft)$/iu;
 const LANGUAGE_LIST_PATTERN = /^(.+?)\s+languages?$/i;
 const WIELD_SHIELD_PATTERN = /^wielding a shield$/i;
 const WEARING_ARMOR_PATTERN = /^wearing\s+(.+?)\s+armor$/i;
@@ -173,6 +184,21 @@ const FALLBACK_SKILL_ALIASES = {
   discretion: 'stealth',
   survie: 'survival',
   vol: 'thievery',
+  akrobatik: 'acrobatics',
+  'arkane kunste': 'arcana',
+  athletik: 'athletics',
+  handwerkskunst: 'crafting',
+  tauschung: 'deception',
+  einschuchtern: 'intimidation',
+  heilkunde: 'medicine',
+  naturkunde: 'nature',
+  okkultismus: 'occultism',
+  darbietung: 'performance',
+  religionskunde: 'religion',
+  gesellschaftskunde: 'society',
+  heimlichkeit: 'stealth',
+  uberlebenskunst: 'survival',
+  diebeskunst: 'thievery',
 };
 
 export function parsePrerequisite(text) {
@@ -237,6 +263,9 @@ export function parsePrerequisite(text) {
 
   const backgroundMatch = tryParseBackgroundRequirement(baseText, trimmed);
   if (backgroundMatch) return backgroundMatch;
+
+  const ancestryMatch = tryParseAncestryRequirement(baseText, trimmed);
+  if (ancestryMatch) return ancestryMatch;
 
   const heritageMatch = tryParseHeritageRequirement(baseText, trimmed);
   if (heritageMatch) return heritageMatch;
@@ -820,6 +849,20 @@ function tryParseHeritageRequirement(text, fullText = text) {
 
   return {
     type: 'heritage',
+    slug,
+    text: fullText,
+  };
+}
+
+function tryParseAncestryRequirement(text, fullText = text) {
+  const match = text.match(ANCESTRY_PATTERN);
+  if (!match) return null;
+
+  const slug = slugify(match[1]);
+  if (!slug) return null;
+
+  return {
+    type: 'ancestry',
     slug,
     text: fullText,
   };

--- a/scripts/prerequisites/prerequisite-checker.js
+++ b/scripts/prerequisites/prerequisite-checker.js
@@ -13,6 +13,7 @@ import {
   matchClassFeature,
   matchBackground,
   matchHeritage,
+  matchAncestry,
   matchAncestryFeatAccess,
   matchProficiency,
   matchClassHp,
@@ -218,6 +219,8 @@ function evaluateLeaf(parsed, buildState) {
       return wrapLeafResult(matchBackground(parsed, buildState));
     case 'heritage':
       return wrapLeafResult(matchHeritage(parsed, buildState));
+    case 'ancestry':
+      return wrapLeafResult(matchAncestry(parsed, buildState));
     case 'ancestryFeatAccess':
       return wrapLeafResult(matchAncestryFeatAccess(parsed, buildState));
     case 'proficiency':

--- a/scripts/ui/feat-picker.js
+++ b/scripts/ui/feat-picker.js
@@ -1519,7 +1519,7 @@ export class FeatPicker extends HandlebarsApplicationMixin(ApplicationV2) {
   }
 
   _decoratePrereqResult(result) {
-    const text = this._titleCase(String(result?.text ?? ''));
+    const text = this._formatPrerequisiteText(result?.text);
     return {
       ...result,
       text,
@@ -1580,14 +1580,29 @@ export class FeatPicker extends HandlebarsApplicationMixin(ApplicationV2) {
 
   _colorizePrereqRanks(text) {
     const escaped = this._escapeHtml(text);
-    return escaped.replace(/\b(Untrained|Trained|Expert|Master|Legendary)\b(?=\s+(?:In|En)\b)/g, (match) => {
-      const rankName = String(match).toLowerCase();
+    const rankNames = {
+      untrained: 'untrained',
+      trained: 'trained',
+      expert: 'expert',
+      master: 'master',
+      legendary: 'legendary',
+      ungeübt: 'untrained',
+      geübt: 'trained',
+      experte: 'expert',
+      meister: 'master',
+      legende: 'legendary',
+    };
+    return escaped.replace(/(Untrained|Trained|Expert|Master|Legendary|Ungeübt|Geübt|Experte|Meister|Legende)(?=\s+(?:in|en)\b)/giu, (match) => {
+      const rankName = rankNames[String(match).toLocaleLowerCase('de')];
       return `<span class="prereq-rank rank-text-${rankName}">${match}</span>`;
     });
   }
 
-  _titleCase(value) {
-    return String(value ?? '').replace(/\b\w/g, (char) => char.toUpperCase());
+  _formatPrerequisiteText(value) {
+    const text = String(value ?? '').trim();
+    if (!text) return '';
+    const [first, ...rest] = [...text];
+    return `${first.toLocaleUpperCase(game.i18n?.lang ?? undefined)}${rest.join('')}`;
   }
 
   _escapeHtml(value) {

--- a/scripts/ui/sheet-integration.js
+++ b/scripts/ui/sheet-integration.js
@@ -18,6 +18,64 @@ export function registerSheetIntegration() {
   Hooks.on('renderSpellPreparationSheetPF2e', onRenderSpellPreparationSheet);
 }
 
+export function registerLevelerKeybindings() {
+  if (!game.keybindings?.register) return;
+
+  game.keybindings.register(MODULE_ID, 'openLevelerForCharacter', {
+    name: 'PF2E_LEVELER.KEYBINDINGS.OPEN_LEVELER.NAME',
+    hint: 'PF2E_LEVELER.KEYBINDINGS.OPEN_LEVELER.HINT',
+    editable: [{ key: 'KeyL', modifiers: ['Shift'] }],
+    precedence: globalThis.CONST?.KEYBINDING_PRECEDENCE?.NORMAL ?? 0,
+    restricted: false,
+    onDown: () => {
+      const actor = resolveLevelerShortcutActor();
+      if (!actor) {
+        ui.notifications.warn(localize('KEYBINDINGS.NO_ACTOR'));
+        return false;
+      }
+
+      void openLevelerForActor(actor);
+      return true;
+    },
+  });
+}
+
+export function resolveLevelerShortcutActor() {
+  const controlledActors = uniqueUsableActors(
+    (canvas?.tokens?.controlled ?? []).map((token) => token?.actor),
+  );
+  if (controlledActors.length === 1) return controlledActors[0];
+
+  const assignedActor = game.user?.character;
+  if (canUseLevelerForActor(assignedActor)) return assignedActor;
+
+  const worldActors = game.actors?.contents ?? Array.from(game.actors ?? []);
+  const usableActors = uniqueUsableActors(worldActors);
+  return usableActors.length === 1 ? usableActors[0] : null;
+}
+
+function uniqueUsableActors(actors) {
+  const unique = new Map();
+  for (const actor of actors ?? []) {
+    if (!canUseLevelerForActor(actor)) continue;
+    unique.set(actor.id ?? actor.uuid, actor);
+  }
+  return [...unique.values()];
+}
+
+async function openLevelerForActor(actor) {
+  if (!canUseLevelerForActor(actor)) return false;
+  if (isSupportedClass(actor)) {
+    await openPlanner(actor);
+    return true;
+  }
+  if (canOpenCreationWizard(actor)) {
+    await openWizard(actor);
+    return true;
+  }
+  return false;
+}
+
 export function isSupportedClass(actor) {
   const actorClass = actor.class;
   if (!actorClass) return false;
@@ -84,7 +142,7 @@ function onRenderCharacterSheet(sheet, html) {
   if (canOpenCreationWizard(actor)) {
     const createTitle = getCreationButtonTitle(actor);
     const createBtn = $(`
-      <a class="pf2e-leveler-create-btn header-control" data-tooltip="${createTitle}" role="button">
+      <a class="pf2e-leveler-create-btn header-control" data-tooltip="${createTitle}" title="${createTitle}" aria-label="${createTitle}" role="button">
         <i class="fas fa-wand-magic-sparkles"></i>
       </a>
     `);
@@ -101,7 +159,7 @@ function onRenderCharacterSheet(sheet, html) {
   if (isSupportedClass(actor)) {
     const planTitle = localize('UI.OPEN_PLANNER');
     const planBtn = $(`
-      <a class="pf2e-leveler-plan-btn header-control" data-tooltip="${planTitle}" role="button">
+      <a class="pf2e-leveler-plan-btn header-control" data-tooltip="${planTitle}" title="${planTitle}" aria-label="${planTitle}" role="button">
         <i class="fas fa-arrow-up-right-dots"></i>
       </a>
     `);

--- a/styles/components.css
+++ b/styles/components.css
@@ -1325,7 +1325,17 @@
 /* "Awaiting your reply" badge on the actor-sheet launch buttons (rendered in the sheet
    window header, outside .pf2e-leveler — selectors stay unscoped). */
 .pf2e-leveler-create-btn,
-.pf2e-leveler-plan-btn { position: relative; }
+.pf2e-leveler-plan-btn {
+  position: relative;
+  display: inline-flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  flex: 0 0 auto !important;
+  align-items: center;
+  justify-content: center;
+  color: inherit !important;
+  background: transparent !important;
+}
 .pf2e-leveler-comment-badge {
   position: absolute;
   top: -3px;

--- a/tests/unit/data/subclass-spells.test.js
+++ b/tests/unit/data/subclass-spells.test.js
@@ -1,6 +1,14 @@
-import { resolveSpellcastingTradition, resolveSubclassSpells } from '../../../scripts/data/subclass-spells.js';
+import { SUBCLASS_SPELLS, resolveSpellcastingTradition, resolveSubclassSpells } from '../../../scripts/data/subclass-spells.js';
 
 describe('resolveSubclassSpells', () => {
+  test('maps all three Time mystery revelation spells to their correct tiers', () => {
+    expect(SUBCLASS_SPELLS.time.focusSpells).toEqual({
+      initial: 'Compendium.pf2e.spells-srd.Item.UbHK19RYbxRXWgWX',
+      advanced: 'Compendium.pf2e.spells-srd.Item.LbqunTurwXB3u9Vp',
+      greater: 'Compendium.pf2e.spells-srd.Item.MT8usUfwudDVUm5H',
+    });
+  });
+
   test('resolves Genie bloodline variable spells by explicit genie type', () => {
     expect(resolveSubclassSpells('bloodline-genie', { genie: 'janni' }, 2)).toEqual(
       expect.objectContaining({ grantedSpell: 'Compendium.pf2e.spells-srd.Item.0qaqksrGGDj74HXE' }),

--- a/tests/unit/prerequisites/parsers.test.js
+++ b/tests/unit/prerequisites/parsers.test.js
@@ -20,6 +20,30 @@ describe('parsePrerequisite', () => {
     expect(result.minRank).toBe(2);
   });
 
+  test('parses German localized skill rank requirements', () => {
+    expect(parsePrerequisite('Geübt in Athletik')).toEqual(expect.objectContaining({
+      type: 'skill',
+      skill: 'athletics',
+      minRank: 1,
+    }));
+    expect(parsePrerequisite('Experte in Heilkunde')).toEqual(expect.objectContaining({
+      type: 'skill',
+      skill: 'medicine',
+      minRank: 2,
+    }));
+  });
+
+  test('parses ancestry and localized heritage prerequisites', () => {
+    expect(parsePrerequisite('Android ancestry')).toEqual(expect.objectContaining({
+      type: 'ancestry',
+      slug: 'android',
+    }));
+    expect(parsePrerequisite('Hellforge Android Herkunft')).toEqual(expect.objectContaining({
+      type: 'heritage',
+      slug: 'hellforge-android',
+    }));
+  });
+
   test('parses generic any-skill requirement', () => {
     const result = parsePrerequisite('trained in at least one skill');
     expect(result.type).toBe('anySkill');

--- a/tests/unit/prerequisites/prerequisite-checker.test.js
+++ b/tests/unit/prerequisites/prerequisite-checker.test.js
@@ -172,6 +172,37 @@ describe('checkPrerequisites', () => {
     expect(result.met).toBe(true);
   });
 
+  test('matches ancestry and homebrew heritage prerequisites together', () => {
+    const feat = {
+      system: {
+        prerequisites: {
+          value: [
+            { value: 'Android ancestry' },
+            { value: 'Hellforge Android heritage' },
+          ],
+        },
+      },
+    };
+    const result = checkPrerequisites(feat, {
+      ...buildState,
+      ancestrySlug: 'android',
+      ancestryTraits: new Set(['android', 'humanoid']),
+      heritageAliases: new Set(['hellforge-android', 'hellforge-android-heritage']),
+    });
+    expect(result.met).toBe(true);
+  });
+
+  test('meets German localized skill prerequisites', () => {
+    const feat = {
+      system: { prerequisites: { value: [{ value: 'Geübt in Athletik' }] } },
+    };
+    const result = checkPrerequisites(feat, {
+      ...buildState,
+      skills: { ...buildState.skills, athletics: 1 },
+    });
+    expect(result.met).toBe(true);
+  });
+
   test('meets French-only translated skill prerequisites when actor has matching skill', () => {
     const feat = {
       system: {

--- a/tests/unit/ui/feat-picker.test.js
+++ b/tests/unit/ui/feat-picker.test.js
@@ -559,8 +559,8 @@ describe('FeatPicker prerequisite enforcement', () => {
     expect(templated.prereqGroups[0].items).toHaveLength(2);
     expect(templated.prereqGroups[0].items).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ text: 'Master In Occultism', met: false }),
-        expect.objectContaining({ text: 'Master In Religion', met: true }),
+        expect.objectContaining({ text: 'Master in Occultism', met: false }),
+        expect.objectContaining({ text: 'Master in Religion', met: true }),
       ]),
     );
   });
@@ -620,6 +620,31 @@ describe('FeatPicker prerequisite enforcement', () => {
     expect(result.selectionBlocked).toBe(false);
     expect(templated.prereqResults[0].displayHtml).toBe('Trained By A Hellknight Order');
     expect(templated.prereqResults[0].displayHtml).not.toContain('prereq-rank');
+  });
+
+  test('preserves German prerequisite casing and colors localized proficiency ranks', () => {
+    const feat = createFeat({
+      name: 'Deutsches Talent',
+      prereqText: 'Geübt in Athletik',
+      uuid: 'deutsches-talent',
+      slug: 'deutsches-talent',
+    });
+    const picker = new FeatPicker(
+      createActor(),
+      'skill',
+      2,
+      createBuildState({ skills: { athletics: 1 } }),
+      jest.fn(),
+    );
+    picker.allFeats = [feat];
+
+    const [result] = picker._applyFilters();
+    const templated = picker._toTemplateFeat(result);
+
+    expect(templated.prereqResults[0].displayHtml).toBe(
+      '<span class="prereq-rank rank-text-trained">Geübt</span> in Athletik',
+    );
+    expect(templated.prereqResults[0].displayHtml).not.toContain('GeüBt');
   });
 
   test('multi-ancestry feat selection prerequisites pass with adopted ancestry in build state', () => {

--- a/tests/unit/ui/level-context.test.js
+++ b/tests/unit/ui/level-context.test.js
@@ -16,6 +16,11 @@ describe('isAdvancedMulticlassFeatCandidate', () => {
     expect(isAdvancedMulticlassFeatCandidate({ slug: 'advanced-domain' }, source)).toBe(false);
   });
 
+  test('false for the Oracle Advanced Revelation class feat', () => {
+    const source = { system: { slug: 'advanced-revelation', traits: { value: ['oracle'] }, rules: [] } };
+    expect(isAdvancedMulticlassFeatCandidate({ slug: 'advanced-revelation' }, source)).toBe(false);
+  });
+
   test('false for an "Advanced" archetype feat that already grants an item', () => {
     const source = { system: { slug: 'advanced-deity', traits: { value: ['archetype'] }, rules: [{ key: 'GrantItem', uuid: 'Compendium.x.Item.y' }] } };
     expect(isAdvancedMulticlassFeatCandidate({ slug: 'advanced-deity' }, source)).toBe(false);

--- a/tests/unit/ui/sheet-integration.test.js
+++ b/tests/unit/ui/sheet-integration.test.js
@@ -4,7 +4,9 @@ import {
   isActorCharacterSheetApplication,
   isSupportedClass,
   normalizePreparationGroupRank,
+  registerLevelerKeybindings,
   registerSheetIntegration,
+  resolveLevelerShortcutActor,
   shouldRedirectCreationWizardToPlanner,
 } from '../../../scripts/ui/sheet-integration.js';
 import { resetLevelerTemplatePreloadForTests } from '../../../scripts/ui/template-preload.js';
@@ -24,6 +26,47 @@ describe('normalizePreparationGroupRank', () => {
   test('returns null for unsupported group ids', () => {
     expect(normalizePreparationGroupRank('focus')).toBeNull();
     expect(normalizePreparationGroupRank(null)).toBeNull();
+  });
+});
+
+describe('leveler keyboard shortcut', () => {
+  afterEach(() => {
+    delete game.keybindings;
+    delete game.actors;
+    game.user.character = null;
+    canvas.tokens.controlled = [];
+  });
+
+  test('registers Shift+L as an editable Foundry keybinding', () => {
+    game.keybindings = { register: jest.fn() };
+
+    registerLevelerKeybindings();
+
+    expect(game.keybindings.register).toHaveBeenCalledWith(
+      'pf2e-leveler',
+      'openLevelerForCharacter',
+      expect.objectContaining({
+        editable: [{ key: 'KeyL', modifiers: ['Shift'] }],
+        restricted: false,
+        onDown: expect.any(Function),
+      }),
+    );
+  });
+
+  test('prefers one selected character over the assigned character', () => {
+    const selected = createMockActor({ id: 'selected' });
+    const assigned = createMockActor({ id: 'assigned' });
+    canvas.tokens.controlled = [{ actor: selected }];
+    game.user.character = assigned;
+
+    expect(resolveLevelerShortcutActor()).toBe(selected);
+  });
+
+  test('falls back to the only usable world character', () => {
+    const actor = createMockActor({ id: 'only-character' });
+    game.actors = { contents: [actor, { id: 'npc', type: 'npc' }] };
+
+    expect(resolveLevelerShortcutActor()).toBe(actor);
   });
 });
 


### PR DESCRIPTION
Ports a few fixes from my fork back here (see [Darkiyus/Darkis-Better-PF2e-Leveler#4](https://github.com/Darkiyus/Darkis-Better-PF2e-Leveler/pull/4)), with the fork-specific parts stripped out.

## Prerequisite parsing
- Prerequisite text didn't recognize localized (e.g. German) skill-rank or ancestry/heritage phrasing ("Geübt in Athletik", "X Herkunft"), so those prerequisites could never be evaluated.
- There was no dedicated ancestry matcher, so a plain "X ancestry" prerequisite could never resolve as met even when the actor had that ancestry.

## Oracle
- The Time mystery's revelation spells were missing their "greater" tier entry, and the advanced/greater compendium IDs were swapped.

## Sheet launcher
- The plan/create header buttons lacked `title`/`aria-label`, and the plan button could end up hidden by some sheet themes overriding its display.
- Added an editable Shift+L keybinding as a fallback way to open the planner or creation wizard for the assigned or currently-controlled character, for cases where the header button isn't visible/reachable.

Verified with `npm run lint` and `npm test` against this repo (99 suites / 1721 tests passing).